### PR TITLE
Falling back to running no tests for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,4 @@ jobs:
        - image: circleci/clojure:lein
      steps:
        - checkout
-       - run: lein doo once
+       - run: lein test


### PR DESCRIPTION
Because we have tests configured to use "lein doo" for which we need to figure out how to setup PhantomJS or any other browser env in CircleCI. 
Doesn't make sense to spend too much time on this now as 
1> We are not sure if this kind of browser-based tests make most sense
2> It doesn't seem (till now) very straightforward to figure how how to do such a setup