### PR TITLE
Sync start timer

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/clojurescript "1.9.908"]
                  [reagent "0.7.0"]
-                 [re-frame "0.10.1"]
+                 [re-frame "0.10.5"]
                  [day8.re-frame/http-fx "0.1.4"]
                  [nilenso/wscljs "0.1.1"]
                  [com.andrewmcveigh/cljs-time "0.5.0"]
@@ -33,7 +33,8 @@
                    [com.cemerick/piggieback "0.2.2"]
                    [figwheel-sidecar "0.5.13"]
                    [pjstadig/humane-test-output "0.8.3"]
-                   [re-frisk "0.5.0"]]
+                   [re-frisk "0.5.0"]
+                   [day8.re-frame/re-frame-10x "0.2.1"]]
 
     :plugins [[lein-figwheel "0.5.13"]
               [lein-doo "0.1.7"]]
@@ -51,11 +52,13 @@
      :compiler     {:main                 time-tracker-web-nxt.core
                     :output-to            "resources/public/js/compiled/app.js"
                     :output-dir           "resources/public/js/compiled/out"
-                    :closure-defines      {time-tracker-web-nxt.config.debug? true}
+                    :closure-defines      {time-tracker-web-nxt.config.debug? true
+                                           "re_frame.trace.trace_enabled_QMARK_" true}
                     :asset-path           "js/compiled/out"
                     :source-map-timestamp true
                     :preloads             [devtools.preload
-                                           re-frisk.preload]
+                                           re-frisk.preload
+                                           day8.re-frame-10x.preload]
                     :external-config      {:devtools/config {:features-to-install :all}}}}
 
     {:id           "min"

--- a/src/cljs/time_tracker_web_nxt/events/ws.cljs
+++ b/src/cljs/time_tracker_web_nxt/events/ws.cljs
@@ -22,7 +22,9 @@
                (timbre/info "Update: " data)
                (if (and (nil? started-time) (> duration 0))
                  (do (timbre/debug "Stopping timer: " id)
-                     (rf/dispatch [:stop-timer data]))))
+                     (rf/dispatch [:stop-timer data]))
+                 (do  (timbre/debug "Received start timer message")
+                      (rf/dispatch [:start-timer (dissoc data :type)]))))
     (timbre/debug "Unknown Action: " data)))
 
 (defn ws-send [[data socket]]

--- a/src/cljs/time_tracker_web_nxt/views.cljs
+++ b/src/cljs/time_tracker_web_nxt/views.cljs
@@ -91,7 +91,7 @@
       :running
       [:span
        [:button.btn.btn-primary
-        {:on-click #(rf/dispatch [:stop-timer timer])}
+        {:on-click #(rf/dispatch [:trigger-stop-timer timer])}
         "Stop"]]
 
       nil)]

--- a/src/cljs/time_tracker_web_nxt/views.cljs
+++ b/src/cljs/time_tracker_web_nxt/views.cljs
@@ -82,7 +82,7 @@
       :paused
       [:span
        [:button.btn.btn-primary
-        {:style {:margin-right 10} :on-click #(rf/dispatch [:resume-timer id])}
+        {:style {:margin-right 10} :on-click #(rf/dispatch [:trigger-start-timer id])}
         "Start"]
        [:button.btn.btn-secondary
         {:on-click #(reset! edit-timer? true)}


### PR DESCRIPTION
Starting a timer in one browser window now starts the timer in another.

![2018-03-22 12 53 50](https://user-images.githubusercontent.com/2477788/37812864-4705449c-2e88-11e8-83cf-e339e5e187d3.gif)

Now, for both start and stop, clicking the button first sends a command to backend, and after receiving an update message, it updates the UI.
 
closes #33 

(me and @samrat paired on this)