### PR TITLE
Fix CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
    build:
      docker:
-       - image: circleci/clojure:lein
+       - image: circleci/clojure:lein-browsers
      steps:
        - checkout
-       - run: lein test
+       - run: lein doo once

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,10 @@ jobs:
        - image: circleci/clojure:lein-browsers
      steps:
        - checkout
+       - restore_cache:
+           key: time-tracker-web-nxt-{{ checksum "project.clj" }}
        - run: lein doo once
+       - save_cache:
+           key: time-tracker-web-nxt-{{ checksum "project.clj" }}
+           paths:
+             - /home/circleci/.m2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # time-tracker-web-nxt
 
+[![CircleCI](https://circleci.com/gh/nilenso/time-tracker-web-nxt.svg?style=svg)](https://circleci.com/gh/nilenso/time-tracker-web-nxt)
+
 A time tracker application brought to you by ClojureScript with all the goodness
 of [re-frame](https://github.com/Day8/re-frame).
 


### PR DESCRIPTION
Previously, we were running `lein test` instead of running CLJS tests via `doo`.

The `lein-browsers` Docker image will have `PhantomJS`(required by `doo`) installed.