### PR TITLE
Sync timers across page loads

### DIFF
--- a/src/cljs/time_tracker_web_nxt/events/api.cljs
+++ b/src/cljs/time_tracker_web_nxt/events/api.cljs
@@ -53,6 +53,8 @@
 
 
 (defn timers-retrieved [db [_ timers]]
+  (when-let [running-timer (first (filter (fn [timer] (:started-time timer)) timers))]
+    (rf/dispatch [:start-timer (select-keys running-timer [:id])]))
   (assoc db :timers (utils/->timer-map timers)))
 
 (defn clients-retrieved [db [_ clients]]

--- a/src/cljs/time_tracker_web_nxt/events/api.cljs
+++ b/src/cljs/time_tracker_web_nxt/events/api.cljs
@@ -53,7 +53,7 @@
 
 
 (defn timers-retrieved [db [_ timers]]
-  (when-let [running-timer (first (filter (fn [timer] (:started-time timer)) timers))]
+  (when-let [running-timer (first (filter :started-time timers))]
     (rf/dispatch [:start-timer (select-keys running-timer [:id])]))
   (assoc db :timers (utils/->timer-map timers)))
 

--- a/src/cljs/time_tracker_web_nxt/events/auth.cljs
+++ b/src/cljs/time_tracker_web_nxt/events/auth.cljs
@@ -11,9 +11,16 @@
   (let [user-profile (auth/user-profile user)
         token        (:token user-profile)]
     {:db         (-> db
-                    (assoc :user user-profile)
-                    (assoc :active-panel :timers))
+                     (assoc :user user-profile)
+                     (assoc :active-panel :timers))
      :dispatch-n [[:get-user-details token]
+                  [:get-projects token]
+                  [:get-timers token (t-coerce/from-date (:timer-date db))]]}))
+
+(defn fetch-data
+  [{:keys [db]} [_]]
+  (let [token (get-in db [:user :token])]
+    {:dispatch-n [[:get-user-details token]
                   [:get-projects token]
                   [:get-timers token (t-coerce/from-date (:timer-date db))]]}))
 
@@ -31,4 +38,5 @@
    [db-spec-inspector ->local-store]
    login)
 
-  (rf/reg-event-fx :log-out logout))
+  (rf/reg-event-fx :log-out logout)
+  (rf/reg-event-fx :fetch-data fetch-data))

--- a/src/cljs/time_tracker_web_nxt/events/timer.cljs
+++ b/src/cljs/time_tracker_web_nxt/events/timer.cljs
@@ -18,19 +18,6 @@
     {:send      [{:command  "start-timer"
                   :timer-id id} socket]}))
 
-(defn tick-running-timer [{:keys [db] :as cofx} _]
-  (let [running?         (fn [timer] (= :running (:state timer)))
-        running-timer-id (first
-                          (for [[k v] (:timers db)
-                                :when (running? v)]
-                            k))
-        fx-map           {:db (assoc db :boot-from-local-storage? false)}]
-    (if running-timer-id
-      (assoc fx-map :tick {:action :start
-                           :id     running-timer-id
-                           :event  [:increment-timer-duration running-timer-id]})
-      fx-map)))
-
 (defn update-timer
   [{:keys [db] :as cofx} [_ timer-id {:keys [elapsed-hh elapsed-mm elapsed-ss notes] :as new}]]
   (let [elapsed    (utils/->seconds elapsed-hh elapsed-mm elapsed-ss)
@@ -106,10 +93,6 @@
    :trigger-start-timer
    [->local-store]
    trigger-start-timer)
-
-  (rf/reg-event-fx
-   :tick-running-timer
-   tick-running-timer)
 
   (tt-reg-event-fx
    :update-timer

--- a/src/cljs/time_tracker_web_nxt/events/ws.cljs
+++ b/src/cljs/time_tracker_web_nxt/events/ws.cljs
@@ -12,12 +12,13 @@
 
 (defn ws-receive
   [{:keys [id started-time duration type] :as data}]
+  ;; In response to a "create-and-start-timer" message, the websocket
+  ;; receives two messages- one "create" and one "update". We only
+  ;; dispatch :start-timer after receiving the "update".
   (case type
     "create" (do
                (timbre/info "Create: " data)
-               (rf/dispatch [:add-timer-to-db (dissoc data :type)])
-               (timbre/debug "Starting timer: " id)
-               (rf/dispatch [:start-timer (dissoc data :type)]))
+               (rf/dispatch [:add-timer-to-db (dissoc data :type)]))
     "update" (do
                (timbre/info "Update: " data)
                (if (and (nil? started-time) (> duration 0))

--- a/src/cljs/time_tracker_web_nxt/events/ws.cljs
+++ b/src/cljs/time_tracker_web_nxt/events/ws.cljs
@@ -23,7 +23,7 @@
                (timbre/info "Update: " data)
                (if (and (nil? started-time) (> duration 0))
                  (do (timbre/debug "Stopping timer: " id)
-                     (rf/dispatch [:stop-timer data]))
+                     (rf/dispatch [:stop-or-update-timer data]))
                  (do  (timbre/debug "Received start timer message")
                       (rf/dispatch [:start-timer (dissoc data :type)]))))
     (timbre/debug "Unknown Action: " data)))

--- a/src/cljs/time_tracker_web_nxt/utils.cljs
+++ b/src/cljs/time_tracker_web_nxt/utils.cljs
@@ -53,9 +53,15 @@
   (if (= 0 duration) :running :paused))
 
 (defn ->timer-map [timers]
-  (reduce #(assoc %1
-                  (:id %2)
-                  (-> %2
-                     (assoc :state (timer-state %2))
-                     (assoc :elapsed (:duration %2))))
-          {} timers))
+  (reduce (fn [acc timer]
+            (assoc acc (:id timer)
+                   (-> timer
+                       (assoc :state (timer-state timer))
+                       (assoc :elapsed
+                              (if (:started-time timer)
+                                (+ (:duration timer)
+                                   (- (int (/ (.getTime (js/Date.)) 1000))
+                                      (:started-time timer)))
+                                (:duration timer))))))
+          {}
+          timers))

--- a/src/cljs/time_tracker_web_nxt/utils.cljs
+++ b/src/cljs/time_tracker_web_nxt/utils.cljs
@@ -52,16 +52,19 @@
   [{:keys [duration] :as timer}]
   (if (= 0 duration) :running :paused))
 
+(defn timer-elapsed
+  [{:keys [duration started-time]}]
+  (let [now-seconds (int (/ (.getTime (js/Date.)) 1000))]
+    (if started-time
+      (+ duration
+         (- now-seconds started-time))
+      duration)))
+
 (defn ->timer-map [timers]
   (reduce (fn [acc timer]
             (assoc acc (:id timer)
                    (-> timer
                        (assoc :state (timer-state timer))
-                       (assoc :elapsed
-                              (if (:started-time timer)
-                                (+ (:duration timer)
-                                   (- (int (/ (.getTime (js/Date.)) 1000))
-                                      (:started-time timer)))
-                                (:duration timer))))))
+                       (assoc :elapsed (timer-elapsed timer)))))
           {}
           timers))

--- a/src/cljs/time_tracker_web_nxt/views.cljs
+++ b/src/cljs/time_tracker_web_nxt/views.cljs
@@ -119,7 +119,7 @@
        [:button
         {:on-click (fn []
                      (reset! edit-timer? false)
-                     (rf/dispatch [:update-timer id @changes]))}
+                     (rf/dispatch [:trigger-update-timer id @changes]))}
         "Update"]])))
 
 (defn timer-row [{:keys [id elapsed project-id notes]}]

--- a/src/cljs/time_tracker_web_nxt/views.cljs
+++ b/src/cljs/time_tracker_web_nxt/views.cljs
@@ -238,16 +238,11 @@
      [user-menu]]))
 
 (defn timers-panel []
-  (let [user     (rf/subscribe [:user])
-        boot-ls? (rf/subscribe [:boot-from-local-storage?])]
-    ;; If loading data from localstorage, start ticking a running timer if any.
-    ;; FIXME: Figure out a better way to do this
-    (if @boot-ls?
-      (rf/dispatch [:tick-running-timer])
-      (do (rf/dispatch [:create-ws-connection (:token @user)])
-          [:div.page
-           [header]
-           [main]]))))
+  (let [user     (rf/subscribe [:user])]
+    (rf/dispatch [:create-ws-connection (:token @user)])
+    [:div.page
+     [header]
+     [main]]))
 
 (defn about-panel []
   [:div.page
@@ -400,4 +395,6 @@
 
 (defn app []
   (let [active-panel (rf/subscribe [:active-panel])]
+    (when (= @active-panel :timers)
+      (rf/dispatch [:fetch-data]))
     [(panels @active-panel)]))

--- a/test/cljs/time_tracker_web_nxt/core_test.cljs
+++ b/test/cljs/time_tracker_web_nxt/core_test.cljs
@@ -94,7 +94,7 @@
           timers   (rf/subscribe [:timers])]
       (rf/dispatch [:add-timer-to-db timer])
       (rf/dispatch [:start-timer timer])
-      (rf/dispatch [:stop-timer timer])
+      (rf/dispatch [:stop-or-update-timer timer])
       (is (= :paused (get-in @timers [2 :state]))))))
 
 (deftest create-and-start-timer-test
@@ -121,19 +121,12 @@
 (deftest update-timer-test
   (testing "user can only update a stopped timer"
     (let [timer    (helpers/make-timer {:id 2})
-          elapsed1 {:elapsed-hh 0 :elapsed-mm 0 :elapsed-ss 10}
-          elapsed2 {:elapsed-hh 0 :elapsed-mm 5 :elapsed-ss 10}
-          elapsed3 {:elapsed-hh 2 :elapsed-mm 5 :elapsed-ss 10}
-          notes    "....."
+          duration 400
+          notes    "some note"
           timer-id (:id timer)
           timers   (rf/subscribe [:timers])]
       (rf/dispatch [:add-timer-to-db timer])
 
-      (rf/dispatch [:update-timer timer-id elapsed1 notes])
-      (is (= 10 (get-in @timers [timer-id :elapsed])))
-
-      (rf/dispatch [:update-timer timer-id elapsed2 notes])
-      (is (= (+ 10 (* 5 60)) (get-in @timers [timer-id :elapsed])))
-
-      (rf/dispatch [:update-timer timer-id elapsed3 notes])
-      (is (= (+ 10 (* 5 60) (* 2 60 60)) (get-in @timers [timer-id :elapsed]))))))
+      (rf/dispatch [:stop-or-update-timer {:id timer-id :duration duration :notes notes}])
+      (is (= duration (get-in @timers [timer-id :elapsed])))
+      (is (= notes (get-in @timers [timer-id :notes]))))))


### PR DESCRIPTION
- Ensure `setInterval` is not triggered more than once for a timer
- Add event `fetch-data` to fetch data from servers every time
  `active-panel` changes to `:timers`.
- Remove `tick-running-timer`. Timers that are running are now started
  in the callback function `timers-retrieved`.
- Update `->timer-map` to set timer's `:elapsed` to the correct value

(@samrat and @hargup paired on this PR)

closes nilenso/time-tracker#125
closes nilenso/time-tracker#137
closes nilenso/time-tracker#159
closes nilenso/time-tracker#160