### PR TITLE
Fix issues with urls and reloads

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -13,7 +13,7 @@
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="css/toastr.min.css">
     <link rel="stylesheet" type="text/css" href="css/style.css"/>
-    <link rel="stylesheet" type="text/css" href="font-awesome-4.7.0/css/font-awesome.min.css"/>
+    <link rel="stylesheet" type="text/css" href="css/font-awesome-4.7.0/css/font-awesome.min.css"/>
   </head>
   <body>
     <div id="app" style="height: 100%"></div>

--- a/src/cljs/time_tracker_web_nxt/auth.cljs
+++ b/src/cljs/time_tracker_web_nxt/auth.cljs
@@ -33,8 +33,8 @@
   (let [c (chan)]
     ;; TODO: Add timeout
     (.load js/gapi "auth2" (fn [] (-> (.init (object/get js/gapi "auth2")
-                                            (clj->js {"client_id" (:client-id config/env)
-                                                      "scope"     (:scope config/env)}))
-                                     (.then #(go (>! c true))
-                                            #(go (>! c false))))))
+                                             (clj->js {"client_id" (:client-id config/env)
+                                                       "scope"     (:scope config/env)}))
+                                      (.then #(go (>! c true))
+                                             #(go (>! c false))))))
     c))

--- a/src/cljs/time_tracker_web_nxt/core.cljs
+++ b/src/cljs/time_tracker_web_nxt/core.cljs
@@ -37,9 +37,9 @@
   ;; The event handler for `:initialize-db` can be found in `events.cljs`
   ;; Using the sync version of dispatch means that value is in
   ;; place before we go onto the next step.
+  (routes/init)
   (re-frame/dispatch-sync [:initialize-db])
-  (routes/routes-init)
   (dev-setup)
-  (go (when-let [c (<! (auth/init!))])
-      (mount-root))
+  (go (when-let [c (<! (auth/init!))]
+        (mount-root)))
   (loading))

--- a/src/cljs/time_tracker_web_nxt/core.cljs
+++ b/src/cljs/time_tracker_web_nxt/core.cljs
@@ -10,7 +10,8 @@
             [time-tracker-web-nxt.subs]
             [time-tracker-web-nxt.views :as views]
             [time-tracker-web-nxt.config :as config]
-            [time-tracker-web-nxt.auth :as auth]))
+            [time-tracker-web-nxt.auth :as auth]
+            [time-tracker-web-nxt.routes :as routes]))
 
 (defn dev-setup []
   "Does specific development related setup."
@@ -37,6 +38,7 @@
   ;; Using the sync version of dispatch means that value is in
   ;; place before we go onto the next step.
   (re-frame/dispatch-sync [:initialize-db])
+  (routes/routes-init)
   (dev-setup)
   (go (when-let [c (<! (auth/init!))])
       (mount-root))

--- a/src/cljs/time_tracker_web_nxt/db.cljs
+++ b/src/cljs/time_tracker_web_nxt/db.cljs
@@ -41,7 +41,6 @@
 
 (def default-db
   {:app-name "the future Time Tracker"
-   :active-panel :sign-in
    :timers {}
    :timer-date (js/Date. (.setHours (js/Date.) 0 0 0 0))
    :projects []

--- a/src/cljs/time_tracker_web_nxt/events/auth.cljs
+++ b/src/cljs/time_tracker_web_nxt/events/auth.cljs
@@ -10,12 +10,12 @@
   [{:keys [db] :as cofx} [_ user]]
   (let [user-profile (auth/user-profile user)
         token        (:token user-profile)]
-    {:db         (-> db
-                     (assoc :user user-profile)
-                     (assoc :active-panel :timers))
+    (taoensso.timbre/info "login called")
+    {:db         (assoc db :user user-profile)
      :dispatch-n [[:get-user-details token]
                   [:get-projects token]
-                  [:get-timers token (t-coerce/from-date (:timer-date db))]]}))
+                  [:get-timers token (t-coerce/from-date (:timer-date db))]
+                  [:goto :timers]]}))
 
 (defn fetch-data
   [{:keys [db]} [_]]
@@ -29,7 +29,8 @@
   (let [[_ socket] (:conn db)]
     {:db db/default-db
      :close socket
-     :clear-local-storage nil}))
+     :clear-local-storage nil
+     :dispatch [:goto :sign-in]}))
 
 
 (defn init []

--- a/src/cljs/time_tracker_web_nxt/events/core.cljs
+++ b/src/cljs/time_tracker_web_nxt/events/core.cljs
@@ -9,11 +9,16 @@
    [time-tracker-web-nxt.events.ui :as ui-events]
    [time-tracker-web-nxt.events.ws :as ws-events]))
 
+(defn signed-in? [local-store-app-db]
+  ;; FIXME: We assume that the existance of localstorage means that the user is logged in.
+  (some? local-store-app-db))
+
 (defn initialize-db [{:keys [db local-store-app-db]} cofx]
-  (if local-store-app-db
-    ;; FIXME: We assume that the existance of localstorage means that the user is logged in.
-    {:db (assoc (merge db/default-db local-store-app-db) :active-panel :timers)}
-    {:db db/default-db}))
+  (if (signed-in? local-store-app-db)
+    {:db (merge db/default-db local-store-app-db)}
+    {:db db/default-db
+     :dispatch [:goto :sign-in]}))
+
 
 (defn init []
   (rf/reg-event-fx

--- a/src/cljs/time_tracker_web_nxt/events/ui.cljs
+++ b/src/cljs/time_tracker_web_nxt/events/ui.cljs
@@ -6,10 +6,9 @@
 
 
 (defn set-active-panel-handler [db [_ panel]]
-  (let [status (:show-user-menu? db)]
-    (-> db
-       (assoc :active-panel panel)
-       (assoc :show-user-menu? false))))
+  (-> db
+      (assoc :active-panel panel)
+      (assoc :show-user-menu? false)))
 
 (defn init []
 

--- a/src/cljs/time_tracker_web_nxt/interceptors.cljs
+++ b/src/cljs/time_tracker_web_nxt/interceptors.cljs
@@ -19,12 +19,11 @@
 ;; ENTIRE state of the application after each event handler runs.  All of it.
   (rf/after (partial check-and-throw :time-tracker-web-nxt.db/db)))
 
-
 (defn db->local-store
   "Persists app db to local storage"
   [app-db]
   ;; Remove websocket and response channel
-  (let [new-db (assoc app-db :conn [])]
+  (let [new-db (assoc app-db :conn [])] ;; FIX ME: use dissoc to be more explicit about removing conns
     (set-item local-storage "db" (str (select-keys new-db [:user])))))
 
 ;; This interceptor persists the rf db to local-storage

--- a/src/cljs/time_tracker_web_nxt/routes.cljs
+++ b/src/cljs/time_tracker_web_nxt/routes.cljs
@@ -7,6 +7,7 @@
 
 
 (def routes ["/" {""         :timers
+                  "sign-in"  :sign-in
                   "about"    :about
                   "clients/" {""    :clients
                               "new" :create-client}}])
@@ -21,12 +22,20 @@
                  :handler
                  name
                  keyword)]
-    (rf/dispatch [:set-active-panel panel])))
+    (timbre/info "dispatch-route called with" matched-route)
+    (rf/dispatch [:set-active-panel panel])
+    nil))
 
-(defn dispatch-url [k]
+(def history
   (pushy/pushy dispatch-route parse-url))
 
+(defn goto [_ [_ route-name]]
+  (let [url (url-for route-name)]
+    (pushy/set-token! history url)
+    (dispatch-route (parse-url url))
+    {}))
+
 ;; Start event listeners
-(defn routes-init
-  []
-  (pushy/start! (pushy/pushy dispatch-route parse-url)))
+(defn init []
+  (rf/reg-event-fx :goto goto)
+  (pushy/start! history))

--- a/src/cljs/time_tracker_web_nxt/routes.cljs
+++ b/src/cljs/time_tracker_web_nxt/routes.cljs
@@ -27,4 +27,6 @@
   (pushy/pushy dispatch-route parse-url))
 
 ;; Start event listeners
-(pushy/start! (pushy/pushy dispatch-route parse-url))
+(defn routes-init
+  []
+  (pushy/start! (pushy/pushy dispatch-route parse-url)))

--- a/src/cljs/time_tracker_web_nxt/views.cljs
+++ b/src/cljs/time_tracker_web_nxt/views.cljs
@@ -196,9 +196,8 @@
     [:div.splash-screen
      [:h1.splash-screen-title "Time Tracker"]
      [:a.sign-in {:href     "#"
-                  :on-click (fn [_] (-> (.signIn (auth/auth-instance))
-                                      (.then
-                                       #(rf/dispatch [:log-in %]))))}
+                  :on-click (fn [_] (-> (.signIn (auth/auth-instance)) ;; FIX: handle error cases
+                                        (.then #(rf/dispatch [:log-in %]))))}
       [:img.google-sign-in
        {:src "images/btn_google_signin_light_normal_web@2x.png"
         :alt "Sign in with Google"}]]]))

--- a/test/cljs/time_tracker_web_nxt/core_test.cljs
+++ b/test/cljs/time_tracker_web_nxt/core_test.cljs
@@ -6,6 +6,7 @@
             [time-tracker-web-nxt.core :as core]
             [time-tracker-web-nxt.db :as db]
             [time-tracker-web-nxt.events.core :as e]
+            [time-tracker-web-nxt.routes :as routes]
             [time-tracker-web-nxt.events.ws :as ws-events]
             [time-tracker-web-nxt.interceptors :as interceptors]
             [time-tracker-web-nxt.test-helpers :as helpers]
@@ -48,12 +49,13 @@
      (assoc db :user user)))
 
   (rf/dispatch [:initialize-db])
-  (rf/dispatch [:add-user test-user]))
+  (rf/dispatch [:add-user user]))
 
 (defn fixtures [f]
   (rf-test/run-test-sync
    (with-redefs [interceptors/standard-interceptor stubbed-interceptor]
      (e/init)
+     (routes/init)
      (test-fixtures)
      (f))))
 


### PR DESCRIPTION
- Website load when the user in not signed in, takes them to `/sign-in`
- When signed in, loading `/about` shows the about page
- directing loading `/sign-in` loads the sign-in page instead of 404.

(This PR works out of the box for production though it needs changes in nginx config for local setup)